### PR TITLE
Normalize ISBN attribute by removing hyphens

### DIFF
--- a/app/models/book_master.rb
+++ b/app/models/book_master.rb
@@ -17,4 +17,12 @@ class BookMaster < ApplicationRecord
   belongs_to :ndc_category
   has_many :book_author_relationship
   has_many :authors, through: :book_author_relationship
+
+  before_save :normalize_isbn
+
+  private
+
+  def normalize_isbn
+    self.isbn = isbn.delete('-')
+  end
 end

--- a/example_data/book_master.csv
+++ b/example_data/book_master.csv
@@ -1,8 +1,8 @@
 ISBN,タイトル,著者,発行日,書籍分類
-978-4757506206,鋼の錬金術師1,荒川弘,2002/01/22,絵画（Painting. Pictorial arts）
-978-4757506992,鋼の錬金術師2,荒川弘,2002/05/22,絵画（Painting. Pictorial arts）
-978-4757507913,鋼の錬金術師3,荒川弘,2002/09/21,絵画（Painting. Pictorial arts）
-978-4757508552,鋼の錬金術師4,荒川弘,2003/01/22,絵画（Painting. Pictorial arts）
-978-4757509665,鋼の錬金術師5,荒川弘,2003/06/21,絵画（Painting. Pictorial arts）
-978-4757510470,鋼の錬金術師6,荒川弘,2003/10/22,絵画（Painting. Pictorial arts）
-978-4814400850,Binary Hacks Rebooted —低レイヤの世界を探検するテクニック89選,河田旺|小池悠生|渡邉慶一|佐伯学哉|荒田実樹,2024/8/28,技術、工学（Technology. Engineering）
+9784757506206,鋼の錬金術師1,荒川弘,2002/01/22,絵画（Painting. Pictorial arts）
+9784757506992,鋼の錬金術師2,荒川弘,2002/05/22,絵画（Painting. Pictorial arts）
+9784757507913,鋼の錬金術師3,荒川弘,2002/09/21,絵画（Painting. Pictorial arts）
+9784757508552,鋼の錬金術師4,荒川弘,2003/01/22,絵画（Painting. Pictorial arts）
+9784757509665,鋼の錬金術師5,荒川弘,2003/06/21,絵画（Painting. Pictorial arts）
+9784757510470,鋼の錬金術師6,荒川弘,2003/10/22,絵画（Painting. Pictorial arts）
+9784814400850,Binary Hacks Rebooted —低レイヤの世界を探検するテクニック89選,河田旺|小池悠生|渡邉慶一|佐伯学哉|荒田実樹,2024/8/28,技術、工学（Technology. Engineering）

--- a/test/models/book_master_test.rb
+++ b/test/models/book_master_test.rb
@@ -65,4 +65,10 @@ class BookMasterTest < ActiveSupport::TestCase
     book = BookMaster.new(isbn: "978-0-306-40615-8", title: "Test Book", publication_date: Date.today, ndc_category: ndc_categories(:one))
     assert_not book.valid?
   end
+
+  test "normalize ISBN before save" do
+    book = BookMaster.new(isbn: "978-0-306-40615-7", title: "Test Book", publication_date: Date.today, ndc_category: ndc_categories(:one))
+    book.save
+    assert_equal "9780306406157", book.isbn
+  end
 end


### PR DESCRIPTION
Add normalization of ISBN attribute before saving in `BookMaster` model.

* **Model Changes**
  - Add a `before_save` callback to normalize the `isbn` attribute by removing hyphens in `app/models/book_master.rb`.

* **Test Changes**
  - Add a test case in `test/models/book_master_test.rb` to verify that the `isbn` attribute is normalized by removing hyphens before saving.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/LibrarySystem?shareId=df253bb9-c9e7-47bd-b22a-6f52fe64f373).